### PR TITLE
reader-centric bells and whistles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Paraview graphics files
+*.pvd
+*.vtu
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # firedrake-springerbrief-examples
+
 Numerical examples for the Firedrake Springerbrief:
 > Thomas H. Gibson, Andrew T.T. McRae, Colin J. Cotter, Lawrence Mitchell, and David A. Ham.
-> ``Compatible finite element methods for geophysical flows: Automation and Implementation using Firedrake"
+> _Compatible finite element methods for geophysical flows: Automation and Implementation using Firedrake_,
+> Springer 2019
 
 Running the example `ch5_examples/hydrostatic_balance.py` requires pip installing https://github.com/thomasgibson/scpc. All other examples can be run using the latest Firedrake installation (https://www.firedrakeproject.org/download.html)

--- a/ch3_examples/2d_product_elements.py
+++ b/ch3_examples/2d_product_elements.py
@@ -20,7 +20,7 @@ S = TensorProductElement(P2, dP1)
 Hcurl = FunctionSpace(mesh, HCurl(S))
 Hdiv = FunctionSpace(mesh, HDiv(S))
 
-# visualize functions from these spaces using Paraview
+# visualize functions from these spaces using ParaView
 x, y = SpatialCoordinate(mesh)
 uH1 = Function(H1).interpolate(x*x + y*y)
 uH1.rename('uH1')

--- a/ch3_examples/2d_product_elements.py
+++ b/ch3_examples/2d_product_elements.py
@@ -1,3 +1,5 @@
+# Computations from subsection 3.3.1.
+
 from firedrake import *
 
 N = 20
@@ -17,3 +19,16 @@ L2 = FunctionSpace(mesh, L2_element)
 S = TensorProductElement(P2, dP1)
 Hcurl = FunctionSpace(mesh, HCurl(S))
 Hdiv = FunctionSpace(mesh, HDiv(S))
+
+# visualize functions from these spaces using Paraview
+x, y = SpatialCoordinate(mesh)
+uH1 = Function(H1).interpolate(x*x + y*y)
+uH1.rename('uH1')
+uL2 = Function(L2).interpolate(x*x + y*y)
+uL2.rename('uL2')
+uHcurl = Function(Hcurl).project(as_vector([y*y,x*x]))
+uHcurl.rename('uHcurl')
+uHdiv = Function(Hdiv).project(as_vector([y*y,x*x]))
+uHdiv.rename('uHdiv')
+File("unitsquare.pvd").write(uH1,uL2,uHcurl,uHdiv)
+

--- a/ch3_examples/3d_product_elements.py
+++ b/ch3_examples/3d_product_elements.py
@@ -29,7 +29,7 @@ Hdiv_v = HDiv(TensorProductElement(dP1t, P2i))
 Hdiv_element = Hdiv_h + Hdiv_v
 Hdiv = FunctionSpace(mesh, Hdiv_element)
 
-# visualize functions from these spaces using Paraview
+# visualize functions from these spaces using ParaView
 x, y, z = SpatialCoordinate(mesh)
 uH1 = Function(H1).interpolate(x*x + y*y + z*z)
 uH1.rename('uH1')

--- a/ch3_examples/3d_product_elements.py
+++ b/ch3_examples/3d_product_elements.py
@@ -1,3 +1,5 @@
+# Computations from subsection 3.3.2.
+
 from firedrake import *
 
 N = 10
@@ -26,3 +28,16 @@ Hdiv_h = HDiv(TensorProductElement(RT2, dP1i))
 Hdiv_v = HDiv(TensorProductElement(dP1t, P2i))
 Hdiv_element = Hdiv_h + Hdiv_v
 Hdiv = FunctionSpace(mesh, Hdiv_element)
+
+# visualize functions from these spaces using Paraview
+x, y, z = SpatialCoordinate(mesh)
+uH1 = Function(H1).interpolate(x*x + y*y + z*z)
+uH1.rename('uH1')
+uL2 = Function(L2).interpolate(x*x + y*y + z*z)
+uL2.rename('uL2')
+uHcurl = Function(Hcurl).project(as_vector([z*z,y*y,x*x]))
+uHcurl.rename('uHcurl')
+uHdiv = Function(Hdiv).project(as_vector([z*z,y*y,x*x]))
+uHdiv.rename('uHdiv')
+File("unitcube.pvd").write(uH1,uL2,uHcurl,uHdiv)
+

--- a/ch3_examples/extruded.py
+++ b/ch3_examples/extruded.py
@@ -1,4 +1,4 @@
-# Computations from section 3.2.  Use Paraview to generate something like Fig. 3.2.
+# Computations from section 3.2.  Use Paraview to generate Fig. 3.2.
 
 from firedrake import *
 

--- a/ch3_examples/extruded.py
+++ b/ch3_examples/extruded.py
@@ -1,4 +1,4 @@
-# Computations from section 3.2.  Use Paraview to generate Fig. 3.2.
+# Computations from section 3.2.  Use ParaView to generate Fig. 3.2.
 
 from firedrake import *
 
@@ -7,7 +7,7 @@ base_mesh = CubedSphereMesh(radius=6400.e6, refinement_level=5,
 mesh = ExtrudedMesh(base_mesh, layers=20, layer_height=10,
                     extrusion_type="radial")
 
-# visualize a function from this space with Paraview
+# visualize a function from this space with ParaView
 V = FunctionSpace(mesh, "CG", 1)
 u = Function(V)
 File("cubedsphere.pvd").write(u)

--- a/ch3_examples/extruded.py
+++ b/ch3_examples/extruded.py
@@ -1,6 +1,14 @@
+# Computations from section 3.2.  Use Paraview to generate something like Fig. 3.2.
+
 from firedrake import *
 
 base_mesh = CubedSphereMesh(radius=6400.e6, refinement_level=5,
                             degree=2)
 mesh = ExtrudedMesh(base_mesh, layers=20, layer_height=10,
                     extrusion_type="radial")
+
+# visualize a function from this space with Paraview
+V = FunctionSpace(mesh, "CG", 1)
+u = Function(V)
+File("cubedsphere.pvd").write(u)
+

--- a/ch3_examples/makefile
+++ b/ch3_examples/makefile
@@ -1,0 +1,5 @@
+.PHONY: clean
+
+clean:
+	@rm -f *.pyc *.pvd *.vtu
+

--- a/ch3_examples/stable_mixed_poisson.py
+++ b/ch3_examples/stable_mixed_poisson.py
@@ -1,4 +1,4 @@
-# Computations from section 3.1.  Generate plot similar to Fig. 3.1 (right).
+# Computations from section 3.1.  Generates Fig. 3.1 (right).
 
 from firedrake import *
 

--- a/ch3_examples/stable_mixed_poisson.py
+++ b/ch3_examples/stable_mixed_poisson.py
@@ -1,3 +1,5 @@
+# Computations from section 3.1.  Generate plot similar to Fig. 3.1 (right).
+
 from firedrake import *
 
 mesh = UnitSquareMesh(16, 16)
@@ -19,7 +21,11 @@ L = f*v*dx
 w = Function(W, name="Solution")
 solve(a == L, w)
 
-sigma_h, u_h = w.split()
-plot(u_h)
+# visualize
 import matplotlib.pyplot as plt
+sigma_h, u_h = w.split()
+pic = tripcolor(u_h, cmap='coolwarm')
+plt.axis('equal')
+plt.colorbar(pic)
 plt.show()
+

--- a/ch3_examples/stokes_auxiliary_pc.py
+++ b/ch3_examples/stokes_auxiliary_pc.py
@@ -1,4 +1,7 @@
+# Computations from section 3.4.1, solving a lid-driven cavity Stokes problem.  Generate plot similar to Fig. 3.8.
+
 from firedrake import *
+
 mesh = UnitSquareMesh(64, 64)
 
 V = VectorFunctionSpace(mesh, "CG", 2)
@@ -44,7 +47,6 @@ solver_parameters = {
     }
 }
 
-
 class MassMatrix(AuxiliaryOperatorPC):
     _prefix = "mass_"
     def form(self, pc, test, trial):
@@ -60,7 +62,11 @@ solve(F == 0, w,
       appctx=appctx,
       solver_parameters=solver_parameters)
 
+# visualize
 u_h, p_h = w.split()
-plot(u_h)
 import matplotlib.pyplot as plt
+pic = quiver(u_h, cmap='coolwarm')
+plt.axis('equal')
+plt.colorbar(pic)
 plt.show()
+

--- a/ch3_examples/stokes_auxiliary_pc.py
+++ b/ch3_examples/stokes_auxiliary_pc.py
@@ -1,4 +1,4 @@
-# Computations from section 3.4.1, solving a lid-driven cavity Stokes problem.  Generate plot similar to Fig. 3.8.
+# Computations from section 3.4.1.  Generates Fig. 3.8.
 
 from firedrake import *
 

--- a/ch3_examples/unstable_mixed_poisson.py
+++ b/ch3_examples/unstable_mixed_poisson.py
@@ -1,4 +1,4 @@
-# Computations from section 3.1, but with unstable CG1xDG0 elements.  Generate plot similar to Fig. 3.1 (left).
+# Computations from section 3.1, but with unstable CG1xDG0 elements.  Generates Fig. 3.1 (left).
 
 from firedrake import *
 

--- a/ch3_examples/unstable_mixed_poisson.py
+++ b/ch3_examples/unstable_mixed_poisson.py
@@ -1,5 +1,6 @@
+# Computations from section 3.1, but with unstable CG1xDG0 elements.  Generate plot similar to Fig. 3.1 (left).
+
 from firedrake import *
-import matplotlib.pyplot as plt
 
 mesh = UnitSquareMesh(16, 16)
 
@@ -19,7 +20,12 @@ L = f*v*dx
 w = Function(W, name="Solution")
 
 solve(a == L, w, solver_parameters={'ksp_rtol': 1e-3})
-sigma_h, u_h = w.split()
 
-plot(u_h)
+# visualize
+import matplotlib.pyplot as plt
+sigma_h, u_h = w.split()
+pic = tripcolor(u_h, cmap='coolwarm')
+plt.axis('equal')
+plt.colorbar(pic)
 plt.show()
+

--- a/ch4_examples/.gitignore
+++ b/ch4_examples/.gitignore
@@ -1,0 +1,3 @@
+/results
+/*.pdf
+

--- a/ch4_examples/dg-advection.py
+++ b/ch4_examples/dg-advection.py
@@ -1,3 +1,5 @@
+# Computations from subsection 4.2.1.  Use ParaView to generate Fig. 4.4.
+
 from firedrake import *
 
 mesh = UnitSquareMesh(128, 128, quadrilateral=True)
@@ -39,7 +41,8 @@ slot_cyl = conditional(
 q = Function(V).interpolate(1.0 + bell + cone + slot_cyl)
 q_init = Function(V).assign(q)
 
-outfile = File("results/DGadv.pvd")
+outfile = File("results/DG/DGadv.pvd")
+q.rename("q")
 outfile.write(q)
 
 T = 2*pi
@@ -77,6 +80,7 @@ solv2 = LinearVariationalSolver(prb2, solver_parameters=params)
 prb3 = LinearVariationalProblem(a, L3, dq)
 solv3 = LinearVariationalSolver(prb3, solver_parameters=params)
 
+from firedrake.petsc import PETSc  # for better parallel printing
 t = 0.0
 step = 0
 while t < T - 0.5*dt:
@@ -94,8 +98,9 @@ while t < T - 0.5*dt:
 
     if step % 20 == 0:
         outfile.write(q)
-        print("t=", t)
+        PETSc.Sys.Print("t=%f" % t)
 
 L2_err = errornorm(q, q_init, norm_type="L2")
 L2_init = norm(q_init, norm_type="L2")
-print(L2_err/L2_init)
+PETSc.Sys.Print(L2_err/L2_init)
+

--- a/ch4_examples/makefile
+++ b/ch4_examples/makefile
@@ -1,0 +1,6 @@
+.PHONY: clean
+
+clean:
+	@rm -rf results
+	@rm -f *.pyc *.pvd *.vtu *.pdf
+

--- a/ch4_examples/sw_linear_w2.py
+++ b/ch4_examples/sw_linear_w2.py
@@ -1,3 +1,5 @@
+# Computations from subsection 4.1.1.  Generates Figs. 4.2 and 4.3.  Use ParaView to generate Fig. 4.1.
+
 from firedrake import *
 
 R0 = 6371220.0
@@ -68,7 +70,10 @@ t_array = []
 energy = 0.5*inner(un, un)*H*dx + 0.5*g*hn*hn*dx
 energy_0 = assemble(energy)
 energy_t = []
-while t < tmax:  # Start time loop
+
+# Start time loop
+from firedrake.petsc import PETSc  # for better parallel printing
+while t < tmax:
     t += Dt
     t_array.append(t)
     uh_solver.solve()  # Solve for updated fields
@@ -95,6 +100,7 @@ while t < tmax:  # Start time loop
         h_out.assign(hn)
         outfile.write(u_out, h_out)
         counter -= dumpfreq
+        PETSc.Sys.Print("t=%f days" % (t/day))
 
 
 # plotting
@@ -145,11 +151,11 @@ make_a_plot(t_array, Herrors,
             data_label="Depth errors",
             name="depth_errors.pdf")
 
-# Plot energy
-# t_array.insert(0, 0.0)
+# Plot energy differences
 make_a_plot(t_array, energy_t,
             xlabel="Time (days)", ylabel="Relative energy diff.",
             xlim=[0, 5],
             ylim=None,
             data_label="Relative energy diff.",
             name="energy.pdf")
+

--- a/ch4_examples/sw_nonlinear_w5.py
+++ b/ch4_examples/sw_nonlinear_w5.py
@@ -1,4 +1,7 @@
+# Computations from subsection 4.3.1.  Use ParaView to generate Figs. 4.5 and 4.6.
+
 from firedrake import *
+
 R0 = 6371220.0
 R = Constant(R0)             # Radius of the earth [m]
 H = Constant(5960.0)         # Mean depth [m]
@@ -126,6 +129,7 @@ outfile.write(u_out, h_out)
 File("results/W5/W5_b.pvd").write(b)
 
 # Start time-loop
+from firedrake.petsc import PETSc  # for better parallel printing
 t = 0.0
 dumpfreq = 10    # Dump output every 10 steps
 counter = 1
@@ -158,3 +162,5 @@ while t < tmax:
         h_out.assign(hn + b)
         outfile.write(u_out, h_out)
         counter -= dumpfreq
+        PETSc.Sys.Print("t=%f days" % (t/day))
+


### PR DESCRIPTION
Main thing: Please ignore this if it is not to your taste.

I am reading your delightful book and running all the examples.  I fiddled in the following ways on the Chapters 3 and 4 examples (so far), because I think it makes it clearer to readers how they work and what they do:

- fixed the use of `plot()`, which breaks in current Firedrake, in ch3 codes, to use `tripcolor()` or `quiver()` as appropriate
- add a leading line indicating which (sub)section the code corresponds to, and which figures
- since I am running codes in parallel in ch4, changed the printing to use `PETSc.Sys.Print()`
- added visualization in `{2|3}d_product_elements.py`
- added printing of `t` in days in `sw_linear_w2.py` and `sw_nonlinear_w5.py`
- added `.gitignores` and `makefile`s, the latter just for a `make clean` target to clean up results and figures

I'll do the same fiddles in `ch5_examples/` pretty soon, so no rush to merge.

Only the first item is a bug fix.  If you just want that as a pull request, let me know.